### PR TITLE
Adding Glue GetPartitions MaxResults

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -147,6 +147,7 @@ public class GlueHiveMetastore
     private static final String WILDCARD_EXPRESSION = "";
     private static final int BATCH_GET_PARTITION_MAX_PAGE_SIZE = 1000;
     private static final int BATCH_CREATE_PARTITION_MAX_PAGE_SIZE = 100;
+    private static final int AWS_GLUE_GET_PARTITIONS_MAX_RESULTS = 128;
     private static final Comparator<Partition> PARTITION_COMPARATOR =
             comparing(Partition::getValues, lexicographical(String.CASE_INSENSITIVE_ORDER));
 
@@ -663,7 +664,8 @@ public class GlueHiveMetastore
                             .withCatalogId(catalogId)
                             .withDatabaseName(table.getDatabaseName())
                             .withTableName(table.getTableName())
-                            .withPartitionValues(partitionValues)));
+                            .withPartitionValues(partitionValues)
+                            .withMaxResults(AWS_GLUE_GET_PARTITIONS_MAX_RESULTS)));
             return Optional.of(GlueToPrestoConverter.convertPartition(result.getPartition(), table.getParameters()));
         }
         catch (EntityNotFoundException e) {


### PR DESCRIPTION
This change is supposed to reduce the amount of roundtrips needed to get partitions from Glue Metastore.